### PR TITLE
added ability to specify MySQL user in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 
 ## Built With
-
+Node, Express, Handlebars, MySQL, Sequelize
 
 ## Authors
 
@@ -22,23 +22,31 @@ Users must have [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-
 
 ### **Installing the app**
 
-1) From git bash, Terminal or Command Prompt, clone this repository to a directory on your computer.  <br>
-  ```git clone https://github.com/blahblahblah.git```
-2) Change directory to the Fabulist directory.<br>
-  ```cd Fabulist```
-3) Initialize the app with a package.json file.<br>
-  ```npm init```  
-  Follow the command line instructions.  You can just accept all of the defaults.
-4) Install the app.<br>
-  ```npm install```
-  This will create a node_modules folder and install all of the dependent modules.
+1) From git bash, Terminal or Command Prompt, clone this repository to a directory on your computer.
 
-Users will need to add a file name '.env' to the project folder. 
-  Add this line to the file:
+```
+git clone https://github.com/rami0141/Fabulist
 
-  ```MYSQL_PASSWORD=?????????```
+# change to the application direction
+cd Fabulist
 
-  Replace the question marks with your MySQL password.
+# install the required packages
+npm install
+
+```
+
+
+Users will need to add a file name '.env' to the project folder.
+Add these lines to the file:
+
+```
+MYSQL_PASSWORD=?????????
+MYSQL_USERNAME=?????????
+
+```
+
+Replace the question marks with your MySQL password and username (without these variables, the app will still try to run with default user is root, and password as NULL)
+
 
 ### **Setting up the MySQL database**
 

--- a/models/index.js
+++ b/models/index.js
@@ -5,14 +5,15 @@ var path      = require('path');
 var Sequelize = require('sequelize');
 var basename  = path.basename(module.filename);
 var env       = process.env.NODE_ENV || 'development';
-const mysql_pwd = process.env.MYSQL_PASSWORD;
 var config    = require(__dirname + '/../config/config.json')[env];
+const mysql_pwd = process.env.MYSQL_PASSWORD || config.password;
+const mysql_user = process.env.MYSQL_USERNAME || config.username;
 var db        = {};
 
 if (config.use_env_variable) {
   var sequelize = new Sequelize(process.env[config.use_env_variable]);
 } else {
-  var sequelize = new Sequelize(config.database, config.username, mysql_pwd, config);
+  var sequelize = new Sequelize(config.database, mysql_user, mysql_pwd, config);
 }
 
 fs


### PR DESCRIPTION
I needed to be able to specify a MySQL username. (in the .env file). It should fallback to root if nothing is provided, so I think for those of you already running and using your root mysql user, it should work okay.